### PR TITLE
IAEMOD-3054: Enable customization for evaluating default filters.

### DIFF
--- a/layouts/src/lib/search-list-layout/demo/layout-responsive/layout-responsive.component.ts
+++ b/layouts/src/lib/search-list-layout/demo/layout-responsive/layout-responsive.component.ts
@@ -60,6 +60,9 @@ export class LayoutResponsiveComponent implements AfterViewInit {
       { text: 'Entity Name', value: 'legalBusinessName' },
       { text: 'Status', value: 'registrationStatus' },
     ],
+    // consider the filter config to be default if there is a keyword tag with 
+    // text 'ignore'. This is for demo purpose.
+    isDefaultFilter: (filter) =>  filter?.keyword?.keywordTags?.some((keywordTag) => keywordTag?.text === 'ignore')
   };
 
   /* Sort config change demo */

--- a/layouts/src/lib/search-list-layout/model/search-list-layout.model.ts
+++ b/layouts/src/lib/search-list-layout/model/search-list-layout.model.ts
@@ -106,6 +106,8 @@ export class SearchListConfiguration {
     queryParamsHandling?: QueryParamsHandling;
 
     excludeFilterFields?: SearchExcludeField[];
+
+    isDefaultFilter?: (filter: {[key: string] : any}) => boolean;
 }
 
 export interface ResultsModel {

--- a/layouts/src/lib/search-list-layout/search-list-layout.component.ts
+++ b/layouts/src/lib/search-list-layout/search-list-layout.component.ts
@@ -19,7 +19,7 @@ import {
   SearchListConfiguration,
   ResultsModel,
 } from './model/search-list-layout.model';
-import { distinctUntilChanged} from 'rxjs/operators'; 
+import { distinctUntilChanged } from 'rxjs/operators';
 import {
   SDSFormlyUpdateComunicationService,
   SDSFormlyUpdateModelService,
@@ -47,7 +47,7 @@ export class SearchListLayoutComponent implements OnInit {
     private formlyUpdateComunicationService: SDSFormlyUpdateComunicationService,
     private filterUpdateModelService: SDSFormlyUpdateModelService,
     private loc: Location
-  ) {}
+  ) { }
 
   /**
    * Input service to be called when items change
@@ -154,7 +154,7 @@ export class SearchListLayoutComponent implements OnInit {
     if (this.isHistoryEnabled) {
       this.getHistoryModel();
     }
-    
+
   }
 
   ngOnInit() {
@@ -169,23 +169,23 @@ export class SearchListLayoutComponent implements OnInit {
       this.updateContent();
     });
     this.formlySubscription = this.formlyUpdateComunicationService.filterUpdate
-  .pipe(
-    distinctUntilChanged((prev, curr) => {
-      if (this.triggeredByPopState) {
-        this.lastKnownFilter = _.cloneDeep(curr); // Sync lastKnownFilter with the current filter
-        // popstateEvent = false; // Reset flag after handling
-        return false; // Allow this event through
-      }
+      .pipe(
+        distinctUntilChanged((prev, curr) => {
+          if (this.triggeredByPopState) {
+            this.lastKnownFilter = _.cloneDeep(curr); // Sync lastKnownFilter with the current filter
+            // popstateEvent = false; // Reset flag after handling
+            return false; // Allow this event through
+          }
 
-      // If not popstate, use equality check
-      const isEqual = !_.isEqual(this.lastKnownFilter,curr);
-      this.lastKnownFilter = _.cloneDeep(curr); // Update lastKnownFilter only when a distinct event is detected
-      return !isEqual; // Only pass distinct events afterward
-    })
-  )
-  .subscribe(filter => {
-    this.updateFilter(filter);
-  });
+          // If not popstate, use equality check
+          const isEqual = !_.isEqual(this.lastKnownFilter, curr);
+          this.lastKnownFilter = _.cloneDeep(curr); // Update lastKnownFilter only when a distinct event is detected
+          return !isEqual; // Only pass distinct events afterward
+        })
+      )
+      .subscribe(filter => {
+        this.updateFilter(filter);
+      });
   }
 
   ngOnDestroy() {
@@ -258,7 +258,7 @@ export class SearchListLayoutComponent implements OnInit {
   isDefaultFilter(filter) {
     const cleanModel = this.flatten(filter);
     const op = this.flatten(this.configuration.defaultFilterValue);
-    this.isDefaultModel = _.isEqual(cleanModel, op);
+    this.isDefaultModel = this.configuration.isDefaultFilter?.(filter) ?? _.isEqual(cleanModel, op);
   }
 
   flatten(input, reference?, output?) {
@@ -327,7 +327,7 @@ export class SearchListLayoutComponent implements OnInit {
             : undefined,
         replaceUrl: skipHistoryOnNav || this.triggeredByPopState,
       });
-    this.triggeredByPopState = false;
+      this.triggeredByPopState = false;
     } else {
       const urlTree = this.router.parseUrl(this.loc.path());
       urlTree.queryParams = params;
@@ -411,7 +411,7 @@ export class SearchListLayoutComponent implements OnInit {
       this.filterData &&
       this.service &&
       this.enableApiCall &&
-      !this.isDefaultModel &&  
+      !this.isDefaultModel &&
       this.skipUpdate === false
     ) {
       this.loading = true;


### PR DESCRIPTION
I added new property isDefaultFilter to search-list-layout configuration prop so that the consumer of the component can decide whether the current filter is default or not. This gives more customization to the consumer of the component rather than using a fixed list. if isDefaultFilter is not provided the existing behavior is used as fallback.